### PR TITLE
Handle multiline PDF text output

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -31,7 +31,15 @@ public class PdfGenerator {
 
             content.beginText();
             content.newLineAtOffset(100, 700);
-            content.showText(event.getText());
+
+            float leading = 16f;
+            String[] lines = (event.getText() == null ? "" : event.getText()).split("\\R", -1);
+            for (int i = 0; i < lines.length; i++) {
+                if (i > 0) {
+                    content.newLineAtOffset(0, -leading);
+                }
+                content.showText(lines[i]);
+            }
             content.endText();
             content.close();
 

--- a/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
+++ b/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
@@ -1,0 +1,22 @@
+package ir.ipaam.fileservice.application.service;
+
+import ir.ipaam.fileservice.domain.event.PdfCreatedEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PdfGeneratorTest {
+
+    @Test
+    void generateShouldHandleMultilineText() {
+        PdfGenerator generator = new PdfGenerator();
+        PdfCreatedEvent event = new PdfCreatedEvent();
+        event.setText("First line\nSecond line\nThird line");
+
+        byte[] pdfBytes = generator.generate(event);
+
+        assertNotNull(pdfBytes);
+        assertTrue(pdfBytes.length > 0, "Generated PDF should not be empty");
+    }
+}


### PR DESCRIPTION
## Summary
- render multiline PDF text by splitting event text on newline characters and adjusting the cursor between lines
- add a regression test ensuring PdfGenerator can generate PDFs when provided newline-separated text

## Testing
- `mvn -q test` *(fails: Unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dceed392dc83288f035dfdd470b5aa