### PR TITLE
Disable font subsetting for PDF generation

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -25,7 +25,7 @@ public class PdfGenerator {
                 if (fontStream == null) {
                     throw new IllegalStateException("Font not found in resources: /fonts/IranSans.ttf");
                 }
-                PDType0Font font = PDType0Font.load(doc, fontStream, true);
+                PDType0Font font = PDType0Font.load(doc, fontStream, false);
                 content.setFont(font, 14);
             }
 

--- a/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
+++ b/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
@@ -19,4 +19,16 @@ class PdfGeneratorTest {
         assertNotNull(pdfBytes);
         assertTrue(pdfBytes.length > 0, "Generated PDF should not be empty");
     }
+
+    @Test
+    void generateShouldSupportPersianCharacters() {
+        PdfGenerator generator = new PdfGenerator();
+        PdfCreatedEvent event = new PdfCreatedEvent();
+        event.setText("این یک متن نمونه است\nمتن دوم برای آزمایش");
+
+        byte[] pdfBytes = generator.generate(event);
+
+        assertNotNull(pdfBytes);
+        assertTrue(pdfBytes.length > 0, "Generated PDF with Persian text should not be empty");
+    }
 }


### PR DESCRIPTION
## Summary
- disable font subsetting when loading the IranSans font so PDFBox embeds it without triggering the subsetting race
- extend `PdfGeneratorTest` coverage to include Persian text and ensure non-empty PDF output

## Testing
- `mvn -q test` *(fails: unable to resolve Spring Boot parent POM from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf3eb467c8328af5b40e7c1e57911