### PR TITLE
Fix PDF conversion response handling

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/api/controller/ConversionController.java
+++ b/src/main/java/ir/ipaam/fileservice/api/controller/ConversionController.java
@@ -1,10 +1,9 @@
 package ir.ipaam.fileservice.api.controller;
 
 
+import ir.ipaam.fileservice.application.service.PdfGenerator;
 import ir.ipaam.fileservice.domain.command.CreatePdfCommand;
-import ir.ipaam.fileservice.domain.event.PdfCreatedEvent;
 import org.axonframework.commandhandling.gateway.CommandGateway;
-import org.axonframework.queryhandling.QueryGateway;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @RestController
@@ -21,21 +21,25 @@ import java.util.UUID;
 public class ConversionController {
 
     private final CommandGateway commandGateway;
+    private final PdfGenerator pdfGenerator;
 
-    public ConversionController(CommandGateway commandGateway) {
+    public ConversionController(CommandGateway commandGateway, PdfGenerator pdfGenerator) {
         this.commandGateway = commandGateway;
+        this.pdfGenerator = pdfGenerator;
     }
 
-    @PostMapping(value = "/pdf", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/pdf", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_PDF_VALUE)
     public ResponseEntity<byte[]> convertTxtToPdf(@RequestPart("file") MultipartFile file) throws Exception {
-        String text = new String(file.getBytes()); // read Persian text
+        String text = new String(file.getBytes(), StandardCharsets.UTF_8); // read Persian text
         String id = UUID.randomUUID().toString();
 
+        byte[] pdfBytes = pdfGenerator.generate(text);
+
         // Send command
-        PdfCreatedEvent event = commandGateway.sendAndWait(new CreatePdfCommand(id,text,"IranSans"));
+        commandGateway.sendAndWait(new CreatePdfCommand(id, text, "IranSans", pdfBytes));
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=converted.pdf")
                 .contentType(MediaType.APPLICATION_PDF)
-                .body(event.getPdfBytes());
+                .body(pdfBytes);
     }
 }

--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -13,6 +13,10 @@ import java.io.InputStream;
 @Service
 public class PdfGenerator {
 
+    public byte[] generate(String text) {
+        return generate(new PdfCreatedEvent(null, text, null));
+    }
+
     public byte[] generate(PdfCreatedEvent event) {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             PDDocument doc = new PDDocument();

--- a/src/main/java/ir/ipaam/fileservice/domain/PdfProjection.java
+++ b/src/main/java/ir/ipaam/fileservice/domain/PdfProjection.java
@@ -16,7 +16,10 @@ public class PdfProjection {
 
     @EventHandler
     public void on(PdfCreatedEvent event) {
-        byte[] pdf = pdfGenerator.generate(event);
+        if (event.getPdfBytes() == null) {
+            byte[] pdf = pdfGenerator.generate(event);
+            event.setPdfBytes(pdf);
+        }
         // store in DB, MinIO, filesystem, etc.
     }
 }

--- a/src/main/java/ir/ipaam/fileservice/domain/command/CreatePdfCommand.java
+++ b/src/main/java/ir/ipaam/fileservice/domain/command/CreatePdfCommand.java
@@ -10,10 +10,11 @@ import lombok.Setter;
 @NoArgsConstructor
 @Setter
 @Getter
-public class CreatePdfCommand{
+public class CreatePdfCommand {
     private String conversionId;
     private String text;
     private String fontName;
+    private byte[] pdfBytes;
 }
 
 

--- a/src/main/java/ir/ipaam/fileservice/domain/model/aggregate/ConversionAggregate.java
+++ b/src/main/java/ir/ipaam/fileservice/domain/model/aggregate/ConversionAggregate.java
@@ -22,7 +22,7 @@ public class ConversionAggregate {
         AggregateLifecycle.apply(new PdfCreatedEvent(
             createPdfCommand.getConversionId(),
             createPdfCommand.getText(),
-            null// payload generated later in projection/service
+            createPdfCommand.getPdfBytes()
         ));
     }
 


### PR DESCRIPTION
## Summary
- return the generated PDF payload directly from the conversion endpoint and declare the binary response type
- include the generated PDF bytes with the CreatePdfCommand so the aggregate stores the completed document
- ensure the projection backfills PDF bytes only when they are absent

## Testing
- mvn -q test *(fails: unable to resolve Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf72bb418832887d3338ce171446b