### PR TITLE
Fix RTL Persian text rendering in generated PDFs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
             <version>${pdfbox.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>75.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${open-api.version}</version>

--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -1,14 +1,19 @@
 package ir.ipaam.fileservice.application.service;
 
+import com.ibm.icu.text.ArabicShaping;
+import com.ibm.icu.text.ArabicShapingException;
+import com.ibm.icu.text.Bidi;
 import ir.ipaam.fileservice.domain.event.PdfCreatedEvent;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.util.regex.Pattern;
 
 @Service
 public class PdfGenerator {
@@ -16,6 +21,12 @@ public class PdfGenerator {
     public byte[] generate(String text) {
         return generate(new PdfCreatedEvent(null, text, null));
     }
+
+    private static final Pattern RTL_PATTERN = Pattern.compile("[\\p{InArabic}]");
+
+    private static final ArabicShaping ARABIC_SHAPING = new ArabicShaping(
+            ArabicShaping.LETTERS_SHAPE | ArabicShaping.TEXT_DIRECTION_VISUAL_LTR
+    );
 
     public byte[] generate(PdfCreatedEvent event) {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -25,26 +36,40 @@ public class PdfGenerator {
 
             PDPageContentStream content = new PDPageContentStream(doc, page);
 
+            PDFont font;
             try (InputStream fontStream = getClass().getResourceAsStream("/fonts/IranSans.ttf")) {
                 if (fontStream == null) {
                     throw new IllegalStateException("Font not found in resources: /fonts/IranSans.ttf");
                 }
-                PDType0Font font = PDType0Font.load(doc, fontStream, false);
-                content.setFont(font, 14);
+                font = PDType0Font.load(doc, fontStream, false);
             }
 
-            content.beginText();
-            content.newLineAtOffset(100, 700);
-
+            float fontSize = 14f;
             float leading = 16f;
+            float margin = 100f;
+            float startY = page.getMediaBox().getHeight() - margin;
+            float rightLimit = page.getMediaBox().getWidth() - margin;
+
             String[] lines = (event.getText() == null ? "" : event.getText()).split("\\R", -1);
             for (int i = 0; i < lines.length; i++) {
-                if (i > 0) {
-                    content.newLineAtOffset(0, -leading);
+                PreparedLine preparedLine = prepareLine(lines[i]);
+                float yPosition = startY - (i * leading);
+                float xPosition;
+
+                if (preparedLine.rtl()) {
+                    float textWidth = font.getStringWidth(preparedLine.text()) / 1000 * fontSize;
+                    xPosition = rightLimit - textWidth;
+                } else {
+                    xPosition = margin;
                 }
-                content.showText(lines[i]);
+
+                content.beginText();
+                content.setFont(font, fontSize);
+                content.newLineAtOffset(xPosition, yPosition);
+                content.showText(preparedLine.text());
+                content.endText();
             }
-            content.endText();
+
             content.close();
 
             doc.save(out);
@@ -53,5 +78,31 @@ public class PdfGenerator {
         } catch (Exception e) {
             throw new RuntimeException("PDF generation failed", e);
         }
+    }
+
+    private PreparedLine prepareLine(String line) {
+        if (line == null || line.isEmpty()) {
+            return new PreparedLine("", false);
+        }
+
+        if (!containsRtlCharacters(line)) {
+            return new PreparedLine(line, false);
+        }
+
+        try {
+            String shaped = ARABIC_SHAPING.shape(line);
+            Bidi bidi = new Bidi(shaped, Bidi.DIRECTION_DEFAULT_RIGHT_TO_LEFT);
+            String visual = bidi.writeReordered(Bidi.DO_MIRRORING);
+            return new PreparedLine(visual, true);
+        } catch (ArabicShapingException e) {
+            throw new RuntimeException("Unable to shape RTL text", e);
+        }
+    }
+
+    private boolean containsRtlCharacters(String line) {
+        return RTL_PATTERN.matcher(line).find();
+    }
+
+    private record PreparedLine(String text, boolean rtl) {
     }
 }


### PR DESCRIPTION
## Summary
- add ICU4J dependency to support shaping and bidi processing for right-to-left languages
- update PdfGenerator to detect RTL lines, shape them correctly, and align them from the right margin when writing to the PDF

## Testing
- mvn -q -e -DskipTests compile *(fails: unable to download org.springframework.boot:spring-boot-starter-parent:3.5.5 due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf97cb0208328b3f9b5b97603c16e