### PR TITLE
Fix RTL shaping direction for Persian text

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -25,7 +25,7 @@ public class PdfGenerator {
     private static final Pattern RTL_PATTERN = Pattern.compile("[\\p{InArabic}]");
 
     private static final ArabicShaping ARABIC_SHAPING = new ArabicShaping(
-            ArabicShaping.LETTERS_SHAPE | ArabicShaping.TEXT_DIRECTION_VISUAL_LTR
+            ArabicShaping.LETTERS_SHAPE | ArabicShaping.TEXT_DIRECTION_LOGICAL
     );
 
     public byte[] generate(PdfCreatedEvent event) {


### PR DESCRIPTION
## Summary
- update Arabic shaping configuration to use logical text direction so the bidi algorithm can reorder RTL text correctly

## Testing
- Not run (Maven repository access blocked in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dcfb5d629c8328856f703ef18907ac