### PR TITLE
Normalize shaped Arabic text output

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.text.Normalizer;
 import java.util.regex.Pattern;
 
 @Service
@@ -93,7 +94,8 @@ public class PdfGenerator {
             String shaped = ARABIC_SHAPING.shape(line);
             Bidi bidi = new Bidi(shaped, Bidi.DIRECTION_DEFAULT_RIGHT_TO_LEFT);
             String visual = bidi.writeReordered(Bidi.DO_MIRRORING);
-            return new PreparedLine(visual, true);
+            String normalized = Normalizer.normalize(visual, Normalizer.Form.NFKC);
+            return new PreparedLine(normalized, true);
         } catch (ArabicShapingException e) {
             throw new RuntimeException("Unable to shape RTL text", e);
         }


### PR DESCRIPTION
## Summary
- normalize bidi-shaped RTL text using NFKC to avoid presentation form glyphs in generated PDFs

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve Spring Boot parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfdc5b7bc8328a36c28bcf18be7a0