### PR TITLE
Improve RTL shaping for Persian text in PDFs

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -93,7 +93,12 @@ public class PdfGenerator {
         try {
             String shaped = ARABIC_SHAPING.shape(line);
             Bidi bidi = new Bidi(shaped, Bidi.DIRECTION_DEFAULT_RIGHT_TO_LEFT);
-            String visual = bidi.writeReordered(Bidi.DO_MIRRORING);
+            bidi.setReorderingMode(Bidi.REORDER_DEFAULT);
+            String visual = bidi.writeReordered(
+                    Bidi.DO_MIRRORING |
+                            Bidi.OUTPUT_REVERSE |
+                            Bidi.INSERT_LRM_FOR_NUMBERS
+            );
             String normalized = Normalizer.normalize(visual, Normalizer.Form.NFKC);
             return new PreparedLine(normalized, true);
         } catch (ArabicShapingException e) {


### PR DESCRIPTION
## Summary
- adjust ICU bidi processing to reverse RTL runs and insert LRM markers so Persian glyphs render in visual order

## Testing
- mvn -q -DskipTests package *(fails: Maven cannot download the Spring Boot parent POM in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd04002f008328a0968814bd86b696