### PR TITLE
Switch PDF generation to Apache FOP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <pdfbox.version>3.0.5</pdfbox.version>
+        <fop.version>2.10</fop.version>
         <open-api.version>2.8.13</open-api.version>
     </properties>
 
@@ -91,18 +91,11 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- PDFBox -->
+        <!-- Apache FOP for PDF generation -->
         <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox</artifactId>
-            <version>${pdfbox.version}</version>
-        </dependency>
-
-        <!-- Needed for fonts (optional but recommended) -->
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>fontbox</artifactId>
-            <version>${pdfbox.version}</version>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>fop</artifactId>
+            <version>${fop.version}</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.icu</groupId>

--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -4,20 +4,43 @@ import com.ibm.icu.text.ArabicShaping;
 import com.ibm.icu.text.ArabicShapingException;
 import com.ibm.icu.text.Bidi;
 import ir.ipaam.fileservice.domain.event.PdfCreatedEvent;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
-import org.apache.pdfbox.pdmodel.font.PDFont;
-import org.apache.pdfbox.pdmodel.font.PDType0Font;
+import org.apache.fop.apps.FOPException;
+import org.apache.fop.apps.FOUserAgent;
+import org.apache.fop.apps.Fop;
+import org.apache.fop.apps.FopFactory;
+import org.apache.fop.apps.MimeConstants;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.text.Normalizer;
 import java.util.regex.Pattern;
 
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.stream.StreamSource;
+
 @Service
 public class PdfGenerator {
+
+    private static final FopFactory FOP_FACTORY;
+
+    static {
+        try {
+            FOP_FACTORY = FopFactory.newInstance(PdfGenerator.class.getResource("/").toURI());
+        } catch (FOPException | java.net.URISyntaxException e) {
+            throw new IllegalStateException("Unable to initialize FOP factory", e);
+        }
+    }
 
     public byte[] generate(String text) {
         return generate(new PdfCreatedEvent(null, text, null));
@@ -31,54 +54,94 @@ public class PdfGenerator {
 
     public byte[] generate(PdfCreatedEvent event) {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            PDDocument doc = new PDDocument();
-            PDPage page = new PDPage();
-            doc.addPage(page);
+            Path fontPath = copyFontToTempFile();
+            try {
+                String foContent = buildFoDocument(event, fontPath.toUri().toString());
 
-            PDPageContentStream content = new PDPageContentStream(doc, page);
+                FOUserAgent foUserAgent = FOP_FACTORY.newFOUserAgent();
+                Fop fop = FOP_FACTORY.newFop(MimeConstants.MIME_PDF, foUserAgent, out);
 
-            PDFont font;
-            try (InputStream fontStream = getClass().getResourceAsStream("/fonts/IranSans.ttf")) {
-                if (fontStream == null) {
-                    throw new IllegalStateException("Font not found in resources: /fonts/IranSans.ttf");
+                TransformerFactory factory = TransformerFactory.newInstance();
+                Transformer transformer = factory.newTransformer();
+                Source src = new StreamSource(new StringReader(foContent));
+                Result res = new SAXResult(fop.getDefaultHandler());
+                transformer.transform(src, res);
+            } finally {
+                try {
+                    Files.deleteIfExists(fontPath);
+                } catch (IOException ignored) {
+                    // If the temporary font cannot be deleted, let the JVM handle it via deleteOnExit.
                 }
-                font = PDType0Font.load(doc, fontStream, false);
             }
-
-            float fontSize = 14f;
-            float leading = 16f;
-            float margin = 100f;
-            float startY = page.getMediaBox().getHeight() - margin;
-            float rightLimit = page.getMediaBox().getWidth() - margin;
-
-            String[] lines = (event.getText() == null ? "" : event.getText()).split("\\R", -1);
-            for (int i = 0; i < lines.length; i++) {
-                PreparedLine preparedLine = prepareLine(lines[i]);
-                float yPosition = startY - (i * leading);
-                float xPosition;
-
-                if (preparedLine.rtl()) {
-                    float textWidth = font.getStringWidth(preparedLine.text()) / 1000 * fontSize;
-                    xPosition = rightLimit - textWidth;
-                } else {
-                    xPosition = margin;
-                }
-
-                content.beginText();
-                content.setFont(font, fontSize);
-                content.newLineAtOffset(xPosition, yPosition);
-                content.showText(preparedLine.text());
-                content.endText();
-            }
-
-            content.close();
-
-            doc.save(out);
-            doc.close();
             return out.toByteArray();
-        } catch (Exception e) {
+        } catch (IOException | TransformerException | FOPException e) {
             throw new RuntimeException("PDF generation failed", e);
         }
+    }
+
+    private Path copyFontToTempFile() throws IOException {
+        try (InputStream fontStream = getClass().getResourceAsStream("/fonts/IranSans.ttf")) {
+            if (fontStream == null) {
+                throw new IllegalStateException("Font not found in resources: /fonts/IranSans.ttf");
+            }
+            Path tempFile = Files.createTempFile("iran-sans", ".ttf");
+            Files.copy(fontStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
+            tempFile.toFile().deleteOnExit();
+            return tempFile;
+        }
+    }
+
+    private String buildFoDocument(PdfCreatedEvent event, String fontUri) {
+        StringBuilder foBuilder = new StringBuilder();
+        foBuilder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        foBuilder.append("<fo:root xmlns:fo=\"http://www.w3.org/1999/XSL/Format\">\n");
+        foBuilder.append("  <fo:layout-master-set>\n");
+        foBuilder.append("    <fo:simple-page-master master-name=\"simple\" page-height=\"29.7cm\" page-width=\"21cm\" margin=\"2cm\">\n");
+        foBuilder.append("      <fo:region-body margin-top=\"1cm\" margin-bottom=\"1cm\"/>\n");
+        foBuilder.append("    </fo:simple-page-master>\n");
+        foBuilder.append("  </fo:layout-master-set>\n");
+        foBuilder.append("  <fo:declarations>\n");
+        foBuilder.append("    <fo:font-face font-family=\"IranSans\" src=\"url('" + fontUri + "')\"/>\n");
+        foBuilder.append("  </fo:declarations>\n");
+        foBuilder.append("  <fo:page-sequence master-reference=\"simple\">\n");
+        foBuilder.append("    <fo:flow flow-name=\"xsl-region-body\">\n");
+
+        String[] lines = (event.getText() == null ? "" : event.getText()).split("\\\R", -1);
+        for (String line : lines) {
+            PreparedLine preparedLine = prepareLine(line);
+            foBuilder.append("      <fo:block font-family=\"IranSans\" font-size=\"14pt\" line-height=\"16pt\"");
+            if (preparedLine.rtl()) {
+                foBuilder.append(" text-align=\"end\" writing-mode=\"rl-tb\" direction=\"rtl\"");
+            } else {
+                foBuilder.append(" text-align=\"start\"");
+            }
+            foBuilder.append(">");
+            foBuilder.append(escapeXml(preparedLine.text()));
+            foBuilder.append("</fo:block>\n");
+        }
+
+        foBuilder.append("    </fo:flow>\n");
+        foBuilder.append("  </fo:page-sequence>\n");
+        foBuilder.append("</fo:root>");
+        return foBuilder.toString();
+    }
+
+    private String escapeXml(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder escaped = new StringBuilder();
+        for (char ch : value.toCharArray()) {
+            switch (ch) {
+                case '&' -> escaped.append("&amp;");
+                case '<' -> escaped.append("&lt;");
+                case '>' -> escaped.append("&gt;");
+                case '\"' -> escaped.append("&quot;");
+                case '\'' -> escaped.append("&apos;");
+                default -> escaped.append(ch);
+            }
+        }
+        return escaped.toString();
     }
 
     private PreparedLine prepareLine(String line) {


### PR DESCRIPTION
## Summary
- replace PDFBox dependencies with Apache FOP
- reimplement PdfGenerator to render FO markup through FOP while preserving RTL shaping
- embed the IranSans font in generated PDFs via a temporary resource copy

## Testing
- `mvn -q -DskipTests package` *(fails: Unable to download Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0a5e3bdc8328a402c36d1b56814f