### PR TITLE
Add HTML/CSS to PDF conversion endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,16 @@
             <version>75.1</version>
         </dependency>
         <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-pdfbox</artifactId>
+            <version>1.0.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-slf4j</artifactId>
+            <version>1.0.10</version>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${open-api.version}</version>

--- a/src/main/java/ir/ipaam/fileservice/api/controller/ConversionController.java
+++ b/src/main/java/ir/ipaam/fileservice/api/controller/ConversionController.java
@@ -1,6 +1,7 @@
 package ir.ipaam.fileservice.api.controller;
 
 
+import ir.ipaam.fileservice.application.service.HtmlCssPdfGenerator;
 import ir.ipaam.fileservice.application.service.PdfGenerator;
 import ir.ipaam.fileservice.domain.command.CreatePdfCommand;
 import org.axonframework.commandhandling.gateway.CommandGateway;
@@ -22,10 +23,12 @@ public class ConversionController {
 
     private final CommandGateway commandGateway;
     private final PdfGenerator pdfGenerator;
+    private final HtmlCssPdfGenerator htmlCssPdfGenerator;
 
-    public ConversionController(CommandGateway commandGateway, PdfGenerator pdfGenerator) {
+    public ConversionController(CommandGateway commandGateway, PdfGenerator pdfGenerator, HtmlCssPdfGenerator htmlCssPdfGenerator) {
         this.commandGateway = commandGateway;
         this.pdfGenerator = pdfGenerator;
+        this.htmlCssPdfGenerator = htmlCssPdfGenerator;
     }
 
     @PostMapping(value = "/pdf", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_PDF_VALUE)
@@ -39,6 +42,22 @@ public class ConversionController {
         commandGateway.sendAndWait(new CreatePdfCommand(id, text, "IranSans", pdfBytes));
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=converted.pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdfBytes);
+    }
+
+    @PostMapping(value = "/pdf/html", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_PDF_VALUE)
+    public ResponseEntity<byte[]> convertHtmlToPdf(@RequestPart("html") MultipartFile htmlFile,
+                                                   @RequestPart(value = "css", required = false) MultipartFile cssFile) throws Exception {
+        String htmlContent = new String(htmlFile.getBytes(), StandardCharsets.UTF_8);
+        String cssContent = cssFile != null ? new String(cssFile.getBytes(), StandardCharsets.UTF_8) : "";
+        String id = UUID.randomUUID().toString();
+
+        byte[] pdfBytes = htmlCssPdfGenerator.generate(htmlContent, cssContent);
+
+        commandGateway.sendAndWait(new CreatePdfCommand(id, htmlContent, "IranSans", pdfBytes));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=converted-html.pdf")
                 .contentType(MediaType.APPLICATION_PDF)
                 .body(pdfBytes);
     }

--- a/src/main/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGenerator.java
@@ -1,0 +1,89 @@
+package ir.ipaam.fileservice.application.service;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+@Service
+public class HtmlCssPdfGenerator {
+
+    public byte[] generate(String htmlContent, String cssContent) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            String document = buildDocument(htmlContent, cssContent);
+
+            PdfRendererBuilder builder = new PdfRendererBuilder();
+            builder.useFastMode();
+            builder.withHtmlContent(document, null);
+            builder.useFont(this::loadIranSansFont, "IranSans");
+            builder.toStream(outputStream);
+            builder.run();
+
+            return outputStream.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate PDF from HTML content", e);
+        }
+    }
+
+    private InputStream loadIranSansFont() {
+        InputStream stream = getClass().getResourceAsStream("/fonts/IranSans.ttf");
+        if (stream == null) {
+            throw new IllegalStateException("Font not found in resources: /fonts/IranSans.ttf");
+        }
+        return stream;
+    }
+
+    private String buildDocument(String htmlContent, String cssContent) {
+        String safeHtml = htmlContent == null ? "" : htmlContent;
+        String safeCss = cssContent == null ? "" : cssContent;
+
+        if (containsHtmlTag(safeHtml)) {
+            return injectCssIntoExistingDocument(safeHtml, safeCss);
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\">");
+        if (!safeCss.isBlank()) {
+            builder.append("<style>").append(safeCss).append("</style>");
+        }
+        builder.append("</head><body>").append(safeHtml).append("</body></html>");
+        return builder.toString();
+    }
+
+    private boolean containsHtmlTag(String htmlContent) {
+        String lower = htmlContent.toLowerCase();
+        return lower.contains("<html") && lower.contains("</html>");
+    }
+
+    private String injectCssIntoExistingDocument(String htmlContent, String cssContent) {
+        if (cssContent.isBlank()) {
+            return htmlContent;
+        }
+
+        String lower = htmlContent.toLowerCase();
+        int headCloseIndex = lower.indexOf("</head>");
+        if (headCloseIndex != -1) {
+            return htmlContent.substring(0, headCloseIndex) +
+                    "<style>" + cssContent + "</style>" +
+                    htmlContent.substring(headCloseIndex);
+        }
+
+        int headOpenIndex = lower.indexOf("<head");
+        if (headOpenIndex != -1) {
+            int headEnd = lower.indexOf('>', headOpenIndex);
+            if (headEnd != -1) {
+                return htmlContent.substring(0, headEnd + 1) +
+                        "<style>" + cssContent + "</style>" +
+                        htmlContent.substring(headEnd + 1);
+            }
+        }
+
+        int bodyIndex = lower.indexOf("<body");
+        if (bodyIndex != -1) {
+            return "<html><head><style>" + cssContent + "</style></head>" + htmlContent.substring(bodyIndex);
+        }
+
+        return "<html><head><style>" + cssContent + "</style></head><body>" + htmlContent + "</body></html>";
+    }
+}

--- a/src/test/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGeneratorTest.java
+++ b/src/test/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGeneratorTest.java
@@ -1,0 +1,32 @@
+package ir.ipaam.fileservice.application.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HtmlCssPdfGeneratorTest {
+
+    private final HtmlCssPdfGenerator generator = new HtmlCssPdfGenerator();
+
+    @Test
+    void shouldGeneratePdfFromHtmlAndCss() {
+        String html = "<div class='title'>Hello World</div>";
+        String css = ".title { font-size: 24px; color: #333333; text-align: center; }";
+
+        byte[] pdfBytes = generator.generate(html, css);
+
+        assertNotNull(pdfBytes);
+        assertTrue(pdfBytes.length > 0, "Generated PDF should not be empty");
+    }
+
+    @Test
+    void shouldGeneratePdfWhenHtmlDocumentProvided() {
+        String html = "<!DOCTYPE html><html><head><title>Sample</title></head><body><p>سلام دنیا</p></body></html>";
+
+        byte[] pdfBytes = generator.generate(html, "");
+
+        assertNotNull(pdfBytes);
+        assertTrue(pdfBytes.length > 0, "Generated PDF should not be empty");
+    }
+}


### PR DESCRIPTION
## Summary
- add OpenHTMLToPDF dependencies to support HTML and CSS rendering
- implement an HtmlCssPdfGenerator service and expose a new conversion endpoint
- cover the generator with unit tests for markup-only and full HTML documents

## Testing
- mvn -q test *(fails: unable to download Spring Boot parent POM – HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e0deef0e2c83289c7279d097eb2517