### PR TITLE
Sanitize HTML entities before PDF rendering

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGenerator.java
@@ -35,7 +35,7 @@ public class HtmlCssPdfGenerator {
     }
 
     private String buildDocument(String htmlContent, String cssContent) {
-        String safeHtml = htmlContent == null ? "" : htmlContent;
+        String safeHtml = htmlContent == null ? "" : normalizeHtmlEntities(htmlContent);
         String safeCss = cssContent == null ? "" : cssContent;
 
         if (containsHtmlTag(safeHtml)) {
@@ -85,5 +85,13 @@ public class HtmlCssPdfGenerator {
         }
 
         return "<html><head><style>" + cssContent + "</style></head><body>" + htmlContent + "</body></html>";
+    }
+
+    private String normalizeHtmlEntities(String htmlContent) {
+        if (htmlContent.isEmpty()) {
+            return htmlContent;
+        }
+
+        return htmlContent.replace("&nbsp;", "&#160;");
     }
 }


### PR DESCRIPTION
## Summary
- normalize incoming HTML so non-breaking spaces are converted to XML-safe numeric entities before rendering to PDF

## Testing
- mvn -q -DskipTests package *(fails: unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e459a0a08328b8cff115f42c4bb8