### PR TITLE
Tidy HTML markup before PDF rendering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
             <version>1.0.10</version>
         </dependency>
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${open-api.version}</version>

--- a/src/main/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGenerator.java
@@ -1,10 +1,14 @@
 package ir.ipaam.fileservice.application.service;
 
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Entities;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 @Service
 public class HtmlCssPdfGenerator {
@@ -35,7 +39,7 @@ public class HtmlCssPdfGenerator {
     }
 
     private String buildDocument(String htmlContent, String cssContent) {
-        String safeHtml = htmlContent == null ? "" : htmlContent;
+        String safeHtml = htmlContent == null ? "" : normalizeHtmlMarkup(htmlContent);
         String safeCss = cssContent == null ? "" : cssContent;
 
         if (containsHtmlTag(safeHtml)) {
@@ -85,5 +89,23 @@ public class HtmlCssPdfGenerator {
         }
 
         return "<html><head><style>" + cssContent + "</style></head><body>" + htmlContent + "</body></html>";
+    }
+
+    private String normalizeHtmlMarkup(String htmlContent) {
+        if (htmlContent.isEmpty()) {
+            return htmlContent;
+        }
+
+        Document document = Jsoup.parse(htmlContent);
+        document.outputSettings()
+                .syntax(Document.OutputSettings.Syntax.xml)
+                .escapeMode(Entities.EscapeMode.xhtml)
+                .charset(StandardCharsets.UTF_8)
+                .prettyPrint(false);
+
+        String normalized = document.outerHtml();
+        return normalized
+                .replace("&nbsp;", "&#160;")
+                .replace(" ", "&#160;");
     }
 }


### PR DESCRIPTION
## Summary
- parse incoming HTML with jsoup to produce well-formed XHTML before PDF rendering
- continue normalizing non-breaking spaces to XML-safe numeric entities

## Testing
- mvn -q -DskipTests package *(fails: Maven Central 403 on parent POM download)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e459a0a08328b8cff115f42c4bb8