### PR TITLE
Ensure IranSans font is applied when generating HTML PDFs

### DIFF
--- a/src/test/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGeneratorTest.java
+++ b/src/test/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGeneratorTest.java
@@ -2,6 +2,8 @@ package ir.ipaam.fileservice.application.service;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,5 +30,15 @@ class HtmlCssPdfGeneratorTest {
 
         assertNotNull(pdfBytes);
         assertTrue(pdfBytes.length > 0, "Generated PDF should not be empty");
+    }
+
+    @Test
+    void shouldInjectIranSansFontCssIntoGeneratedDocument() throws Exception {
+        Method buildDocument = HtmlCssPdfGenerator.class.getDeclaredMethod("buildDocument", String.class, String.class);
+        buildDocument.setAccessible(true);
+
+        String document = (String) buildDocument.invoke(generator, "<p>سلام دنیا</p>", "");
+
+        assertTrue(document.contains("font-family: 'IranSans'"), "Generated document should reference IranSans font");
     }
 }


### PR DESCRIPTION
## Summary
- prepend default IranSans font-face CSS when converting HTML/CSS to PDF so Persian text renders correctly
- always inject the default styling into existing HTML documents during PDF generation
- add a regression test that verifies the generated document references the IranSans font

## Testing
- `mvn -q test` *(fails: unable to resolve spring-boot-starter-parent 3.5.5 due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e79b7e0483289e867ebe8e04cace