### PR TITLE
Support Vazir font when generating PDFs

### DIFF
--- a/src/test/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGeneratorTest.java
+++ b/src/test/java/ir/ipaam/fileservice/application/service/HtmlCssPdfGeneratorTest.java
@@ -2,6 +2,8 @@ package ir.ipaam.fileservice.application.service;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,5 +30,16 @@ class HtmlCssPdfGeneratorTest {
 
         assertNotNull(pdfBytes);
         assertTrue(pdfBytes.length > 0, "Generated PDF should not be empty");
+    }
+
+    @Test
+    void shouldInjectPersianFontCssIntoGeneratedDocument() throws Exception {
+        Method buildDocument = HtmlCssPdfGenerator.class.getDeclaredMethod("buildDocument", String.class, String.class);
+        buildDocument.setAccessible(true);
+
+        String document = (String) buildDocument.invoke(generator, "<p>سلام دنیا</p>", "");
+
+        assertTrue(document.contains("font-family: 'Vazir'"), "Generated document should reference Vazir font");
+        assertTrue(document.contains("font-family: 'IranSans'"), "Generated document should include IranSans fallback");
     }
 }


### PR DESCRIPTION
## Summary
- register both Vazir and IranSans font families with the PDF renderer so Persian text renders even when templates request Vazir
- expand the default injected CSS to advertise both Vazir and IranSans with Vazir as the preferred font
- update regression coverage to verify the generated document references both Vazir and IranSans font families

## Testing
- `mvn -q test` *(fails: unable to resolve spring-boot-starter-parent 3.5.5 due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e79b7e0483289e867ebe8e04cace