### PR TITLE
Normalize Persian text before PDF rendering

### DIFF
--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -38,7 +38,7 @@ public class PdfGenerator {
             PDPageContentStream content = new PDPageContentStream(doc, page);
 
             PDFont font;
-            try (InputStream fontStream = getClass().getResourceAsStream("/fonts/Mitra.ttf")) {
+            try (InputStream fontStream = getClass().getResourceAsStream("/fonts/IranSans.ttf")) {
                 if (fontStream == null) {
                     throw new IllegalStateException("Font not found in resources: /fonts/IranSans.ttf");
                 }
@@ -87,7 +87,7 @@ public class PdfGenerator {
         }
 
 
-        String normalizedLine = line.replaceAll("ی(?!\\b)", "ي");        // Step 2: If no RTL chars, just return
+        String normalizedLine = normalizePersianText(line);
         if (!containsRtlCharacters(normalizedLine)) {
             return new PreparedLine(normalizedLine, false);
         }
@@ -105,6 +105,22 @@ public class PdfGenerator {
 
     private boolean containsRtlCharacters(String line) {
         return RTL_PATTERN.matcher(line).find();
+    }
+
+    private String normalizePersianText(String line) {
+        String normalized = Normalizer.normalize(line, Normalizer.Form.NFKC);
+
+        StringBuilder builder = new StringBuilder(normalized.length());
+        for (int i = 0; i < normalized.length(); i++) {
+            char ch = normalized.charAt(i);
+            builder.append(switch (ch) {
+                case '\u064A', '\u0649', '\u06D2' -> '\u06CC';
+                case '\u0643' -> '\u06A9';
+                default -> ch;
+            });
+        }
+
+        return builder.toString();
     }
 
     private record PreparedLine(String text, boolean rtl) {

--- a/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
+++ b/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
@@ -31,4 +31,16 @@ class PdfGeneratorTest {
         assertNotNull(pdfBytes);
         assertTrue(pdfBytes.length > 0, "Generated PDF with Persian text should not be empty");
     }
+
+    @Test
+    void generateShouldSupportPersianSpecificLetters() {
+        PdfGenerator generator = new PdfGenerator();
+        PdfCreatedEvent event = new PdfCreatedEvent();
+        event.setText("ی گ پ چ");
+
+        byte[] pdfBytes = generator.generate(event);
+
+        assertNotNull(pdfBytes);
+        assertTrue(pdfBytes.length > 0, "Generated PDF with Persian specific letters should not be empty");
+    }
 }


### PR DESCRIPTION
## Summary
- load the bundled IranSans font when generating PDFs so Persian glyphs are available
- normalize lines using NFC/NFKC and remap Arabic code points to their Persian forms before shaping for RTL layout
- add a regression test to ensure characters specific to Persian such as ی گ پ چ are handled

## Testing
- `mvn -q test` *(fails: repository access requires network which is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1051abb6c8328858313fc5874bb2a