### PR TITLE
Use HarfBuzz pipeline for PDF generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <java.version>21</java.version>
         <fop.version>2.10</fop.version>
         <open-api.version>2.8.13</open-api.version>
+        <harfbuzz.version>0.12.2</harfbuzz.version>
     </properties>
 
     <dependencies>
@@ -111,6 +112,16 @@
             <groupId>com.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-slf4j</artifactId>
             <version>1.0.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-harf-buzz</artifactId>
+            <version>1.0.10</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.azagniotov</groupId>
+            <artifactId>java-harfbuzz</artifactId>
+            <version>${harfbuzz.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
+++ b/src/main/java/ir/ipaam/fileservice/application/service/PdfGenerator.java
@@ -1,112 +1,118 @@
 package ir.ipaam.fileservice.application.service;
 
-import com.ibm.icu.text.ArabicShaping;
-import com.ibm.icu.text.ArabicShapingException;
-import com.ibm.icu.text.Bidi;
 import ir.ipaam.fileservice.domain.event.PdfCreatedEvent;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
-import org.apache.pdfbox.pdmodel.font.PDFont;
-import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.springframework.stereotype.Service;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.text.Normalizer;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 @Service
 public class PdfGenerator {
 
+    private static final Pattern RTL_PATTERN = Pattern.compile("[\\p{InARABIC}]");
+
+    private static final String TEXT_LAYOUT_CSS = """
+            body {
+                margin: 48px 64px;
+                font-size: 14px;
+                line-height: 1.6;
+                background-color: #ffffff;
+            }
+            .text-wrapper {
+                display: flex;
+                flex-direction: column;
+                gap: 8px;
+                width: 100%;
+            }
+            .text-line {
+                font-family: 'Vazir', 'IranSans', sans-serif;
+                word-break: break-word;
+                white-space: pre-wrap;
+            }
+            .text-line.rtl {
+                direction: rtl;
+                unicode-bidi: isolate;
+                text-align: right;
+            }
+            .text-line.ltr {
+                direction: ltr;
+                unicode-bidi: isolate;
+                text-align: left;
+            }
+            .text-line.empty {
+                min-height: 1.2em;
+            }
+            """;
+
+    private final HtmlCssPdfGenerator htmlCssPdfGenerator;
+
+    public PdfGenerator(HtmlCssPdfGenerator htmlCssPdfGenerator) {
+        this.htmlCssPdfGenerator = htmlCssPdfGenerator;
+    }
+
     public byte[] generate(String text) {
         return generate(new PdfCreatedEvent(null, text, null));
     }
 
-    private static final Pattern RTL_PATTERN = Pattern.compile("[\\p{InARABIC}]");
-
-    private static final ArabicShaping ARABIC_SHAPING = new ArabicShaping(
-            ArabicShaping.LETTERS_SHAPE | ArabicShaping.TEXT_DIRECTION_LOGICAL
-    );
-
     public byte[] generate(PdfCreatedEvent event) {
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            PDDocument doc = new PDDocument();
-            PDPage page = new PDPage();
-            doc.addPage(page);
-
-            PDPageContentStream content = new PDPageContentStream(doc, page);
-
-            PDFont font;
-            try (InputStream fontStream = getClass().getResourceAsStream("/fonts/Mitra.ttf")) {
-                if (fontStream == null) {
-                    throw new IllegalStateException("Font not found in resources: /fonts/IranSans.ttf");
-                }
-                font = PDType0Font.load(doc, fontStream, false);
-            }
-
-            float fontSize = 14f;
-            float leading = 16f;
-            float margin = 100f;
-            float startY = page.getMediaBox().getHeight() - margin;
-            float rightLimit = page.getMediaBox().getWidth() - margin;
-
-            String[] lines = (event.getText() == null ? "" : event.getText()).split("\\R", -1);
-            for (int i = 0; i < lines.length; i++) {
-                PreparedLine preparedLine = prepareLine(lines[i]);
-                float yPosition = startY - (i * leading);
-                float xPosition;
-
-                if (preparedLine.rtl()) {
-                    float textWidth = font.getStringWidth(preparedLine.text()) / 1000 * fontSize;
-                    xPosition = rightLimit - textWidth;
-                } else {
-                    xPosition = margin;
-                }
-
-                content.beginText();
-                content.setFont(font, fontSize);
-                content.newLineAtOffset(xPosition, yPosition);
-                content.showText(preparedLine.text());
-                content.endText();
-            }
-
-            content.close();
-
-            doc.save(out);
-            doc.close();
-            return out.toByteArray();
-        } catch (Exception e) {
-            throw new RuntimeException("PDF generation failed", e);
-        }
+        String text = event.getText();
+        String htmlDocument = wrapTextAsHtml(text == null ? "" : text);
+        return htmlCssPdfGenerator.generate(htmlDocument, TEXT_LAYOUT_CSS);
     }
 
-    private PreparedLine prepareLine(String line) {
-        if (line == null || line.isEmpty()) {
-            return new PreparedLine("", false);
-        }
+    private String wrapTextAsHtml(String text) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<div class=\"text-wrapper\">");
 
+        Arrays.stream(text.split("\\R", -1))
+                .map(this::sanitizeLine)
+                .forEach(line -> appendLine(builder, line, escapeHtml(line)));
 
-        String normalizedLine = line.replaceAll("ی(?!\\b)", "ي");        // Step 2: If no RTL chars, just return
-        if (!containsRtlCharacters(normalizedLine)) {
-            return new PreparedLine(normalizedLine, false);
-        }
-
-        try {
-            String shaped = ARABIC_SHAPING.shape(normalizedLine);
-            Bidi bidi = new Bidi(shaped, Bidi.DIRECTION_DEFAULT_RIGHT_TO_LEFT);
-            String visual = bidi.writeReordered(Bidi.DO_MIRRORING);
-            String normalized = Normalizer.normalize(visual, Normalizer.Form.NFC);
-            return new PreparedLine(normalized, true);
-        } catch (ArabicShapingException e) {
-            throw new RuntimeException("Unable to shape RTL text", e);
-        }
+        builder.append("</div>");
+        return builder.toString();
     }
 
-    private boolean containsRtlCharacters(String line) {
-        return RTL_PATTERN.matcher(line).find();
+    private String sanitizeLine(String line) {
+        return line == null ? "" : line;
     }
 
-    private record PreparedLine(String text, boolean rtl) {
+    private void appendLine(StringBuilder builder, String original, String escaped) {
+        boolean isEmpty = escaped.isEmpty();
+        String cssClass = containsRtlCharacters(original) ? "rtl" : "ltr";
+        String classes = "text-line " + cssClass + (isEmpty ? " empty" : "");
+
+        builder.append("<div class=\"")
+                .append(classes)
+                .append("\" dir=\"")
+                .append(cssClass)
+                .append("\"");
+
+        if ("rtl".equals(cssClass)) {
+            builder.append(" lang=\"fa\"");
+        }
+
+        builder.append(isEmpty ? ">&#8203;" : ">")
+                .append(isEmpty ? "" : escaped)
+                .append("</div>");
+    }
+
+    private boolean containsRtlCharacters(String value) {
+        return value != null && RTL_PATTERN.matcher(value).find();
+    }
+
+    private String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String escaped = value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;")
+                .replace("\u200c", "&#8204;");
+
+        return escaped;
     }
 }

--- a/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
+++ b/src/test/java/ir/ipaam/fileservice/application/service/PdfGeneratorTest.java
@@ -10,7 +10,7 @@ class PdfGeneratorTest {
 
     @Test
     void generateShouldHandleMultilineText() {
-        PdfGenerator generator = new PdfGenerator();
+        PdfGenerator generator = new PdfGenerator(new HtmlCssPdfGenerator());
         PdfCreatedEvent event = new PdfCreatedEvent();
         event.setText("First line\nSecond line\nThird line");
 
@@ -22,7 +22,7 @@ class PdfGeneratorTest {
 
     @Test
     void generateShouldSupportPersianCharacters() {
-        PdfGenerator generator = new PdfGenerator();
+        PdfGenerator generator = new PdfGenerator(new HtmlCssPdfGenerator());
         PdfCreatedEvent event = new PdfCreatedEvent();
         event.setText("این یک متن نمونه است\nمتن دوم برای آزمایش");
 


### PR DESCRIPTION
## Summary
- add HarfBuzz dependencies to the build
- refactor the text PDF generator to reuse the HTML renderer with RTL-aware markup
- update unit tests to use the shared renderer
- ensure RTL lines declare direction/lang attributes and isolate bidi context so Persian glyph order is preserved

## Testing
- mvn -q -DskipTests package *(fails: cannot download org.springframework.boot:spring-boot-starter-parent due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e214c9543c83289e4eceba2f66ddae